### PR TITLE
initial working cronjob template

### DIFF
--- a/openshift/templates/backup/cm-backup-config.yaml
+++ b/openshift/templates/backup/cm-backup-config.yaml
@@ -1,0 +1,18 @@
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: "${JOB_NAME}-config"
+    namespace: "${NAMESPACE}"
+    labels:
+      template: "${JOB_NAME}-config-template"
+      cronjob: "${JOB_NAME}"
+  data:
+    DATABASE_SERVICE_NAME: "${DATABASE_SERVICE_NAME}"
+    DEFAULT_PORT: "${DATABASE_DEFAULT_PORT}"
+    POSTGRESQL_DATABASE: "${DATABASE_NAME}"
+#    BACKUP_STRATEGY: "daily"
+#    RETENTION.NUM_BACKUPS: "${NUM_BACKUPS}"
+    BACKUP_STRATEGY: "rolling"
+    RETENTION.DAILY_BACKUPS: "${DAILY_BACKUPS}"
+    RETENTION.WEEKLY_BACKUPS: "${WEEKLY_BACKUPS}"
+    RETENTION.MONTHLY_BACKUPS: "${MONTHLY_BACKUPS}"

--- a/openshift/templates/backup/tmpl-cronjob.yaml
+++ b/openshift/templates/backup/tmpl-cronjob.yaml
@@ -1,0 +1,108 @@
+- kind: "CronJob"
+  apiVersion: "batch/v1beta1"
+  metadata:
+    name: "${JOB_NAME}"
+    namespace: "${NAMESPACE}"
+    labels:
+      template: "${JOB_NAME}-cronjob-template"
+      cronjob: "${JOB_NAME}"
+  spec:
+    schedule: "${SCHEDULE}"
+    concurrencyPolicy: "Forbid"
+    successfulJobsHistoryLimit: "${{SUCCESS_JOBS_HISTORY_LIMIT}}"
+    failedJobsHistoryLimit: "${{FAILED_JOBS_HISTORY_LIMIT}}"
+    jobTemplate:
+      metadata:
+        labels:
+          template: "${JOB_NAME}-job-template"
+          cronjob: "${JOB_NAME}"
+      spec:
+        backoffLimit: ${JOB_BACKOFF_LIMIT}
+        template:
+          spec:
+            containers:
+              - name: "${JOB_NAME}-cronjob"
+                image: "docker-registry.default.svc:5000/${IMAGE_NAMESPACE}/${SOURCE_IMAGE_NAME}:${TAG_NAME}"
+#                image: backup
+                command:
+                  - "/bin/bash"
+                  - "-c"
+                  - "/backup.sh -1"
+                volumeMounts:
+                  - mountPath: "${BACKUP_DIR}"
+                    name: "backup"
+                env:
+                  - name: BACKUP_DIR
+                    value: "${BACKUP_DIR}"
+                  - name: BACKUP_STRATEGY
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: BACKUP_STRATEGY
+                  - name: NUM_BACKUPS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: NUM_BACKUPS
+                        optional: true
+                  - name: DAILY_BACKUPS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: DAILY_BACKUPS
+                        optional: true
+                  - name: WEEKLY_BACKUPS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: WEEKLY_BACKUPS
+                        optional: true
+                  - name: MONTHLY_BACKUPS
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: MONTHLY_BACKUPS
+                        optional: true
+                  - name: DATABASE_SERVICE_NAME
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: DATABASE_SERVICE_NAME
+                  - name: DEFAULT_PORT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: DEFAULT_PORT
+                        optional: true
+                  - name: POSTGRESQL_DATABASE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: "${JOB_NAME}-config"
+                        key: POSTGRESQL_DATABASE
+                  - name: POSTGRESQL_USER
+                    valueFrom:
+                      secretKeyRef:
+                        name: "${DATABASE_DEPLOYMENT_NAME}"
+                        key: database-user
+                  - name: POSTGRESQL_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: "${DATABASE_DEPLOYMENT_NAME}"
+                        key: database-password
+            volumes:
+              - name: backup
+                persistentVolumeClaim:
+                  claimName: "${JOB_PERSISTENT_STORAGE_NAME}"
+#              - name: backup-config-volume
+#                configMap:
+#                  name: backup-conf
+#                  defaultMode: 420
+#                  items:
+#                    - key: backup.conf
+#                      path: backup.conf
+            restartPolicy: "Never"
+            terminationGracePeriodSeconds: 30
+            activeDeadlineSeconds: 1600
+            dnsPolicy: "ClusterFirst"
+            serviceAccountName: "${JOB_SERVICE_ACCOUNT}"
+            serviceAccount: "${JOB_SERVICE_ACCOUNT}"

--- a/openshift/templates/backup/vars-backup-config.yaml
+++ b/openshift/templates/backup/vars-backup-config.yaml
@@ -1,0 +1,136 @@
+---
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "{$JOB_NAME}-cronjob-template"
+  annotations:
+    description: "Scheduled Task to perform a Database Backup"
+    tags: "cronjob,backup"
+parameters:
+  - name: "JOB_NAME"
+    displayName: "Job Name"
+    description: "Name of the Scheduled Job to Create."
+    value: "bkup-postgresql"
+    required: true
+  - name: "NAMESPACE"
+    displayName: "Project Namespace"
+    description: "Target Namespace"
+    value: devex-von-tools
+    required: true
+  - name: "JOB_PERSISTENT_STORAGE_NAME"
+    displayName: "Backup Persistent Storage Name"
+    description: "Pre-Created PVC to use for backup target"
+    value: "bk-devex-von-tools-a9vlgd1jpsg1"
+    required: true
+  - name: "SCHEDULE"
+    displayName: "Cron Schedule"
+    description: "Cron Schedule to Execute the Job (in UTC)"
+# Currently targeting 5:00 AM Daily
+    value: "0 13 * * *"
+    required: true
+  - name: "SOURCE_IMAGE_NAME"
+    displayName: "Source Image Name"
+    description: "The name of the image to use for this resource."
+    required: true
+    value: "backup"
+  - name: "IMAGE_NAMESPACE"
+    displayName: "Image Namespace"
+    description: "The namespace of the OpenShift project containing the imagestream for the application."
+    required: true
+    value: "devex-von-tools"
+  - name: "TAG_NAME"
+    displayName: "Environment TAG name"
+    description: "The TAG name for this environment, e.g., dev, test, prod"
+    required: true
+    value: "latest"
+  - name: "DATABASE_SERVICE_NAME"
+    displayName: "Database Service Name"
+    description: "The name of the database service."
+    required: true
+    value: "postgresql"
+  - name: "DATABASE_DEFAULT_PORT"
+    displayName: "Database Service Port"
+    description: "The configured port for the database service"
+    required: true
+    value: "5432"
+  - name: "DATABASE_NAME"
+    displayName: "Database Name"
+    description: "The name of the database."
+    required: true
+    value: "TheOrgBook_Database"
+  - name: "DATABASE_DEPLOYMENT_NAME"
+    displayName: "Database Deployment Name"
+    description: "The name associated to the database deployment resources.  In particular, this is used to wire up the credentials associated to the database."
+    required: true
+    value: "postgresql"
+  - name: "BACKUP_STRATEGY"
+    displayName: "Backup Strategy"
+    description: "The strategy to use for backups; for example daily, or rolling."
+    required: true
+    value: "rolling"
+  - name: "BACKUP_DIR"
+    displayName: "The root backup directory"
+    description: "The name of the root backup directory"
+    required: true
+    value: "/backups/"
+  - name: "NUM_BACKUPS"
+    displayName: "The number of backup files to be retained"
+    description: "The number of backup files to be retained.  Used for the `daily` backup strategy.  Ignored when using the `rolling` backup strategy."
+    required: false
+    value: "5"
+  - name: "DAILY_BACKUPS"
+    displayName: "Number of Daily Backups to Retain"
+    description: "The number of daily backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: "7"
+  - name: "WEEKLY_BACKUPS"
+    displayName: "Number of Weekly Backups to Retain"
+    description: "The number of weekly backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: "4"
+  - name: "MONTHLY_BACKUPS"
+    displayName: "Number of Monthly Backups to Retain"
+    description: "The number of monthly backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: "1"
+  - name: "BACKUP_PERIOD"
+    displayName: "Period (d,m,s) between backups in a format used by the sleep command"
+    description: "Period (d,m,s) between backups in a format used by the sleep command"
+    required: true
+    value: "1d"
+  - name: "CONFIG_FILE_NAME"
+    displayName: "Config File Name"
+    description: "The name of the configuration file."
+    required: true
+    value: "backup.conf"
+  - name: "CONFIG_MAP_NAME"
+    displayName: "Config Map Name"
+    description: "The name of the configuration map."
+    required: true
+    value: "backup-conf"
+  - name: "CONFIG_MOUNT_PATH"
+    displayName: "Config Mount Path"
+    description: "The path to use to mount the config file."
+    required: true
+    value: "/"
+  - name: "JOB_SERVICE_ACCOUNT"
+    displayName: "Service Account Name"
+    description: "Name of the Service Account To Exeucte the Job As."
+    value: "default"
+    required: true
+  - name: "SUCCESS_JOBS_HISTORY_LIMIT"
+    displayName: "Successful Job History Limit"
+    description: "The number of successful jobs that will be retained"
+    value: "5"
+    required: true
+  - name: "FAILED_JOBS_HISTORY_LIMIT"
+    displayName: "Failed Job History Limit"
+    description: "The number of failed jobs that will be retained"
+    value: "2"
+    required: true
+  - name: "JOB_BACKOFF_LIMIT"
+    displayName: "Job Backoff Limit"
+    description: "The number of attempts to try for a successful job outcome"
+    value: "0"
+    required: false
+objects:

--- a/openshift/templates/backup/vars-backup-defaults.yaml
+++ b/openshift/templates/backup/vars-backup-defaults.yaml
@@ -1,0 +1,146 @@
+---
+kind: "Template"
+apiVersion: "v1"
+metadata:
+  name: "{$JOB_NAME}-cronjob-template"
+  annotations:
+    description: "Scheduled Task to perform a Database Backup"
+    tags: "cronjob,backup"
+parameters:
+  - name: "JOB_NAME"
+    displayName: "Job Name"
+    description: "Name of the Scheduled Job to Create."
+    value: "backup"
+    required: true
+  - name: "JOB_PERSISTENT_STORAGE_NAME"
+    displayName: "Backup Persistent Storage Name"
+    description: "Pre-Created PVC to use for backup target"
+    value: "NFS-PVC-NAME-GOES-HERE"
+    required: true
+  - name: "SCHEDULE"
+    displayName: "Cron Schedule"
+    description: "Cron Schedule to Execute the Job (in UTC)"
+# Currently targeting 5:00 AM Daily
+    value: "0 13 * * *"
+    required: true
+  - name: "SOURCE_IMAGE_NAME"
+    displayName: "Source Image Name"
+    description: "The name of the image to use for this resource."
+    required: true
+    value: "backup"
+  - name: "IMAGE_NAMESPACE"
+    displayName: "Image Namespace"
+    description: "The namespace of the OpenShift project containing the imagestream for the application."
+    required: true
+    value: "backup-container"
+  - name: "TAG_NAME"
+    displayName: "Environment TAG name"
+    description: "The TAG name for this environment, e.g., dev, test, prod"
+    required: true
+    value: "dev"
+  - name: "DATABASE_SERVICE_NAME"
+    displayName: "Database Service Name"
+    description: "The name of the database service."
+    required: true
+    value: "postgresql"
+  - name: "DATABASE_NAME"
+    displayName: "Database Name"
+    description: "The name of the database."
+    required: true
+    value: "MyDatabase"
+  - name: "DATABASE_DEPLOYMENT_NAME"
+    displayName: "Database Deployment Name"
+    description: "The name associated to the database deployment resources.  In particular, this is used to wire up the credentials associated to the database."
+    required: true
+    value: "postgresql"
+  - name: "BACKUP_STRATEGY"
+    displayName: "Backup Strategy"
+    description: "The strategy to use for backups; for example daily, or rolling."
+    required: true
+    value: "rolling"
+  - name: "FTP_SECRET_KEY"
+    displayName: "FTP Secret Key"
+    description: "The FTP secret key is used to wire up the credentials associated to the FTP."
+    required: true
+    value: "ftp-secret"
+  - name: "FTP_URL"
+    displayName: "FTP Server URL"
+    description: "The URL of the backup FTP server"
+    required: false
+    value: ""
+  - name: "FTP_USER"
+    displayName: "FTP user name"
+    description: "FTP user name"
+    required: false
+    value: ""
+  - name: "FTP_PASSWORD"
+    displayName: "FTP password"
+    description: "FTP password"
+    required: false
+    value: ""
+  - name: "BACKUP_DIR"
+    displayName: "The root backup directory"
+    description: "The name of the root backup directory"
+    required: true
+    value: "/backups/"
+  - name: "NUM_BACKUPS"
+    displayName: "The number of backup files to be retained"
+    description: "The number of backup files to be retained.  Used for the `daily` backup strategy.  Ignored when using the `rolling` backup strategy."
+    required: false
+    value: ""
+  - name: "DAILY_BACKUPS"
+    displayName: "Number of Daily Backups to Retain"
+    description: "The number of daily backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: ""
+  - name: "WEEKLY_BACKUPS"
+    displayName: "Number of Weekly Backups to Retain"
+    description: "The number of weekly backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: ""
+  - name: "MONTHLY_BACKUPS"
+    displayName: "Number of Monthly Backups to Retain"
+    description: "The number of monthly backup files to be retained.  Used for the `rolling` backup strategy."
+    required: false
+    value: ""
+  - name: "BACKUP_PERIOD"
+    displayName: "Period (d,m,s) between backups in a format used by the sleep command"
+    description: "Period (d,m,s) between backups in a format used by the sleep command"
+    required: true
+    value: "1d"
+  - name: "CONFIG_FILE_NAME"
+    displayName: "Config File Name"
+    description: "The name of the configuration file."
+    required: true
+    value: "backup.conf"
+  - name: "CONFIG_MAP_NAME"
+    displayName: "Config Map Name"
+    description: "The name of the configuration map."
+    required: true
+    value: "backup-conf"
+  - name: "CONFIG_MOUNT_PATH"
+    displayName: "Config Mount Path"
+    description: "The path to use to mount the config file."
+    required: true
+    value: "/"
+  - name: "JOB_SERVICE_ACCOUNT"
+    displayName: "Service Account Name"
+    description: "Name of the Service Account To Exeucte the Job As."
+    value: "default"
+    required: true
+  - name: "SUCCESS_JOBS_HISTORY_LIMIT"
+    displayName: "Successful Job History Limit"
+    description: "The number of successful jobs that will be retained"
+    value: "5"
+    required: true
+  - name: "FAILED_JOBS_HISTORY_LIMIT"
+    displayName: "Failed Job History Limit"
+    description: "The number of failed jobs that will be retained"
+    value: "2"
+    required: true
+  - name: "JOB_BACKOFF_LIMIT"
+    displayName: "Job Backoff Limit"
+    description: "The number of attempts to try for a successful job outcome"
+    value: "0"
+    required: false
+objects:


### PR DESCRIPTION
I've got the initial cronjob template working directly from deployment in the lab project.  However I did have to limit the target db's to just one until we can figure out how to do an n+1 environment structure or other method to look for multi-db and secrets from within the template.

* I still need to add the user documentation to the PR.
* you will need to create separate job templates, cm's and secrets for each database you wanted to back up.
* fix templates to include parameters instead of using cat to merge template parameter defaults with object files before processing.

`Please note: you need to set your job time in UTC (as that's the cluster timezone, and the jobs are cluster scheduled)`

