### PR TITLE
Add cron scheduling support to the pod deployment.

### DIFF
--- a/config/backup.conf
+++ b/config/backup.conf
@@ -17,11 +17,11 @@
 # --------------------------------------------------------
 # List your backup schedule(s) here as well.
 # The schedule(s) must be listed as cron tabs that 
-# execute the backup script in 'run once' mode:
-#   - ./backup.sh -1
+# execute the backup script in 'scheduled' mode:
+#   - ./backup.sh -s
 #
 # Example (assuming system's TZ is set to UTC):
-# - 0 10 * * * default ./backup.sh -1
+# - 0 10 * * * default ./backup.sh -s
 #   - Run a backup at 10am UTC (2am Pacific) every day.
 # --------------------------------------------------------
 # Full Example:
@@ -30,5 +30,5 @@
 # wallet-db:5432/tob_holder
 # wallet-db/tob_issuer
 #
-# 0 10 * * * default ./backup.sh -1
+# 0 10 * * * default ./backup.sh -s
 # =========================================================

--- a/config/backup.conf
+++ b/config/backup.conf
@@ -1,4 +1,6 @@
 # =========================================================
+# Databases:
+# ---------------------------------------------------------
 # List the databases you want backed up here.
 # Databases will be backed up in the order they are listed.
 #
@@ -9,4 +11,24 @@
 # Examples:
 # - postgresql/my_database
 # - postgresql:5432/my_database
+#
 # --------------------------------------------------------
+# Cron Scheduling:
+# --------------------------------------------------------
+# List your backup schedule(s) here as well.
+# The schedule(s) must be listed as cron tabs that 
+# execute the backup script in 'run once' mode:
+#   - ./backup.sh -1
+#
+# Example (assuming system's TZ is set to UTC):
+# - 0 10 * * * default ./backup.sh -1
+#   - Run a backup at 10am UTC (2am Pacific) every day.
+# --------------------------------------------------------
+# Full Example:
+# --------------------------------------------------------
+# postgresql:5432/TheOrgBook_Database
+# wallet-db:5432/tob_holder
+# wallet-db/tob_issuer
+#
+# 0 10 * * * default ./backup.sh -1
+# =========================================================

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,24 @@ WORKDIR /
 COPY backup.sh /
 COPY webhook-template.json /
 
-# Set the default CMD to print the usage of the language image.
-CMD sh /backup.sh
+# ========================================================================================================
+# Install go-crond (from https://github.com/BCDevOps/go-crond)
+#  - Adds some additional logging enhancements on top of the upstream project; 
+#    https://github.com/webdevops/go-crond
+#
+# CRON Jobs in OpenShift:
+#  - https://blog.danman.eu/cron-jobs-in-openshift/
+# --------------------------------------------------------------------------------------------------------
+ARG SOURCE_REPO=BCDevOps
+ARG GOCROND_VERSION=0.6.2
+ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
 
+USER root
+RUN chmod ug+x /usr/bin/go-crond
+# ========================================================================================================
+
+# Important - Reset to the base image's user account.
+USER 26
+
+# Set the default CMD.
+CMD sh /backup.sh

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -610,8 +610,8 @@ function formatList(){
 }
 
 function listSettings(){
-  _backupDirectory=${1}
-  _databaseList=${2}
+  _backupDirectory=${1:-$(createBackupFolder 1)}
+  _databaseList=${2:-$(readConf 2>/dev/null)}
   _yellow='\e[33m'
   _nc='\e[0m' # No Color
   _notConfigured="${_yellow}not configured${_nc}"
@@ -770,6 +770,7 @@ function runBackups(){
 }
 
 function startCron(){
+  listSettings
   echo "Starting go-crond as a forground task ..."
   CRON_CMD="go-crond -v --allow-unprivileged ${BACKUP_CONF}"
   exec ${CRON_CMD}
@@ -835,9 +836,7 @@ while getopts clr:f:1sh FLAG; do
   case $FLAG in
     c)
       echoBlue "\nListing configuration settings ..."
-      databases=$(readConf)
-      backupDir=$(createBackupFolder 1)
-      listSettings "${backupDir}" "${databases}"
+      listSettings
       exit 0
       ;;
     l)

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -789,8 +789,9 @@ function runBackups(){
 }
 
 function startCron(){
+  echoBlue "Starting backup process ..."
   listSettings
-  echo "Starting go-crond as a forground task ..."
+  echoBlue "Starting go-crond as a forground task ...\n"
   CRON_CMD="go-crond -v --allow-unprivileged ${BACKUP_CONF}"
   exec ${CRON_CMD}
 }

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -225,9 +225,13 @@ getHostPasswordParam(){
 readConf(){
   (
     if [ -f ${BACKUP_CONF} ]; then
-      # Read in the config minus any comments ...
+      # Read in the config ...
+      #  - Remove all comments
+      #  - Remove any remaining lines that do not match the expected format(s):
+      #     - <Hostname/>/<DatabaseName/>
+      #     - <Hostname/>:<Port/>/<DatabaseName/>
       echo "Reading backup config from ${BACKUP_CONF} ..." >&2
-      _value=$(sed '/^[[:blank:]]*#/d;s/#.*//' ${BACKUP_CONF})
+      _value=$(sed '/^[[:blank:]]*#/d;/#.*/d;/^[a-zA-Z0-9_/-]*\(:[0-9]*\)\?\/[a-zA-Z0-9_/-]*$/!d;' ${BACKUP_CONF})
     fi
 
     if [ -z "${_value}" ]; then
@@ -732,6 +736,7 @@ while true; do
 
   databases=$(readConf)
   backupDir=$(createBackupFolder)
+
   listSettings "${backupDir}" "${databases}"
 
   if [ ! -z "${PRINT_CONFIG}" ]; then


### PR DESCRIPTION
- Integrates go-crond to support cron tab based scheduling.
  - Uses an enhanced version that supports log output from scheduled jobs.
- Auto detects cron settings and switches to Cron Mode when detected.
- Retains backward compatibility for the "Legacy" mode; now the fallback default.
