### PR TITLE
Fix defunct PostgreSQL processes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ COPY webhook-template.json /
 #  - https://blog.danman.eu/cron-jobs-in-openshift/
 # --------------------------------------------------------------------------------------------------------
 ARG SOURCE_REPO=BCDevOps
-ARG GOCROND_VERSION=0.6.2
+ARG GOCROND_VERSION=0.6.3
 ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
 
 USER root


### PR DESCRIPTION
- fixes #33
- Start go-crond as a background task and wait on it.  This ensures the main script remains as PID 1 and can reap any adopted child processes.
- Ensure a proper shutdown.