### PR TITLE
Change cronjob default schedule value

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The following variables are supported in the first iteration of the backup cronj
 | ---- | -------------------- | ------- |
 | BACKUP_STRATEGY | daily | To control the backup strategy used for backups.  This is explained more below. |
 | BACKUP_DIR | /backups/ | The directory under which backups will be stored.  The deployment configuration mounts the persistent volume claim to this location when first deployed. |
+| SCHEDULE | 0 1 * * * | Cron Schedule to Execute the Job (using local cluster system TZ). |
 | NUM_BACKUPS | 31 | For backward compatibility this value is used with the daily backup strategy to set the number of backups to retain before pruning. |
 | DAILY_BACKUPS | 6 | When using the rolling backup strategy this value is used to determine the number of daily (Mon-Sat) backups to retain before pruning. |
 | WEEKLY_BACKUPS | 4 | When using the rolling backup strategy this value is used to determine the number of weekly (Sun) backups to retain before pruning. |

--- a/openshift/templates/backup/backup-cronjob.yaml
+++ b/openshift/templates/backup/backup-cronjob.yaml
@@ -19,9 +19,9 @@ parameters:
     required: true
   - name: "SCHEDULE"
     displayName: "Cron Schedule"
-    description: "Cron Schedule to Execute the Job (in UTC)"
-# Currently targeting 5:00 AM Daily
-    value: "0 13 * * *"
+    description: "Cron Schedule to Execute the Job (using local cluster system TZ)"
+    # Currently targeting 1:00 AM Daily
+    value: "0 1 * * *"
     required: true
   - name: "SOURCE_IMAGE_NAME"
     displayName: "Source Image Name"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

<!-- Describe your changes in detail -->
This PR updates the default schedule in the cronjob to run at 1 AM (local time zone). The documentation was implying UTC time which is no longer the case. 
<!-- Why is this change required? What problem does it solve? -->
This is meant to bring the default to alignment with the backup.conf example.
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation)
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
