### PR TITLE
Match Env Var Keys to ConfigMap Keys for RETENTION options.

### DIFF
--- a/openshift/templates/backup/backup-cronjob.yaml
+++ b/openshift/templates/backup/backup-cronjob.yaml
@@ -135,8 +135,8 @@ objects:
     DEFAULT_PORT: "${DATABASE_DEFAULT_PORT}"
     POSTGRESQL_DATABASE: "${DATABASE_NAME}"
     # BACKUP_STRATEGY: "daily"
-    RETENTION.NUM_BACKUPS: "${NUM_BACKUPS}"
     BACKUP_STRATEGY: "rolling"
+    RETENTION.NUM_BACKUPS: "${NUM_BACKUPS}"
     RETENTION.DAILY_BACKUPS: "${DAILY_BACKUPS}"
     RETENTION.WEEKLY_BACKUPS: "${WEEKLY_BACKUPS}"
     RETENTION.MONTHLY_BACKUPS: "${MONTHLY_BACKUPS}"
@@ -184,25 +184,25 @@ objects:
                     valueFrom:
                       configMapKeyRef:
                         name: "${JOB_NAME}-config"
-                        key: NUM_BACKUPS
+                        key: RETENTION.NUM_BACKUPS
                         optional: true
                   - name: DAILY_BACKUPS
                     valueFrom:
                       configMapKeyRef:
                         name: "${JOB_NAME}-config"
-                        key: DAILY_BACKUPS
+                        key: RETENTION.DAILY_BACKUPS
                         optional: true
                   - name: WEEKLY_BACKUPS
                     valueFrom:
                       configMapKeyRef:
                         name: "${JOB_NAME}-config"
-                        key: WEEKLY_BACKUPS
+                        key: RETENTION.WEEKLY_BACKUPS
                         optional: true
                   - name: MONTHLY_BACKUPS
                     valueFrom:
                       configMapKeyRef:
                         name: "${JOB_NAME}-config"
-                        key: MONTHLY_BACKUPS
+                        key: RETENTION.MONTHLY_BACKUPS
                         optional: true
                   - name: DATABASE_SERVICE_NAME
                     valueFrom:


### PR DESCRIPTION
Small update to backup-cronjob.yaml to synchronize CronJob environment variable keys to ConfigMap keys for RETENTION.

Verified on Common Services Showcase Team GETOK and CHES projects.