### PR TITLE
Using RUN curl instead of ADD to resolve build Docker build issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,8 @@ COPY webhook-template.json /
 # --------------------------------------------------------------------------------------------------------
 ARG SOURCE_REPO=BCDevOps
 ARG GOCROND_VERSION=0.6.3
-ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
+RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/bin/go-crond
+#ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
 
 USER root
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,10 +22,10 @@ COPY webhook-template.json /
 # --------------------------------------------------------------------------------------------------------
 ARG SOURCE_REPO=BCDevOps
 ARG GOCROND_VERSION=0.6.3
-RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/bin/go-crond
 #ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
 
 USER root
+RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/bin/go-crond
 
 RUN chmod ug+x /usr/bin/go-crond
 # ========================================================================================================


### PR DESCRIPTION
# backup-1-build

STEP 7: ARG GOCROND_VERSION=0.6.3
e55ddcc18af7ee9b5dea5822e3b9172f85bcee5eef6afb272e09d61d2013cdb8
STEP 8: ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
error: build error: error building at STEP "ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond": source can't be a URL for COPY