### PR TITLE
Update Docker file from ADD to RUN curl, build issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@ COPY backup.* /
 
 COPY webhook-template.json /
 
+USER root
+
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
 #  - Adds some additional logging enhancements on top of the upstream project; 
@@ -22,9 +24,7 @@ COPY webhook-template.json /
 # --------------------------------------------------------------------------------------------------------
 ARG SOURCE_REPO=BCDevOps
 ARG GOCROND_VERSION=0.6.3
-ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
-
-USER root
+RUN curl https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux -s -o /usr/bin/go-crond
 
 RUN chmod ug+x /usr/bin/go-crond
 # ========================================================================================================


### PR DESCRIPTION
Clean version of suggested https://github.com/BCDevOps/backup-container/pull/45

Resolves the following issue:
```
STEP 7: ARG GOCROND_VERSION=0.6.3
e55ddcc18af7ee9b5dea5822e3b9172f85bcee5eef6afb272e09d61d2013cdb8
STEP 8: ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond
error: build error: error building at STEP "ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/go-crond-64-linux /usr/bin/go-crond": source can't be a URL for COPY
```

Best practices may have changed, they currently suggest curl:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

I also had to move this operation, installing go-crond, after switching to ROOT so that curl had the permissions required to write to /usr/bin/