### PR TITLE
Add support for ignoring SQL errors during postgres database restore.

### DIFF
--- a/docker/backup.config.utils
+++ b/docker/backup.config.utils
@@ -488,4 +488,14 @@ function validateOperation(){
     return ${_rtnCd}
   )
 }
+
+function ignoreErrors(){
+  (
+    if [ ! -z "${IGNORE_ERRORS}" ]; then
+      return 0
+    else
+      return 1
+    fi
+  )
+}
 # ======================================================================================

--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -61,6 +61,10 @@ function onRestoreDatabase(){
     echo -e "Restoring '${_fileName}' to '${_hostname}${_port:+:${_port}}${_database:+/${_database}}' ...\n" >&2
 
     export PGPASSWORD=${_adminPassword}
+    _stopOnErrors="-v ON_ERROR_STOP=1"
+    if ignoreErrors; then
+      _stopOnErrors="-v ON_ERROR_STOP=0"
+    fi
     _rtnCd=0
 
     # Drop
@@ -86,7 +90,7 @@ function onRestoreDatabase(){
 
     # Restore
     if (( ${_rtnCd} == 0 )); then
-      gunzip -c "${_fileName}" | psql -v ON_ERROR_STOP=1 -x -h "${_hostname}" ${_portArg} -d "${_database}"
+      gunzip -c "${_fileName}" | psql ${_stopOnErrors} -x -h "${_hostname}" ${_portArg} -d "${_database}"
       # Get the status code from psql specifically.  ${?} would only provide the status of the last command, psql in this case.
       _rtnCd=${PIPESTATUS[1]}
     fi

--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -31,7 +31,7 @@ if [[ ${?} != 0 ]]; then
   . ./backup.${CONTAINER_TYPE}.plugin > /dev/null 2>&1
 fi
 
-while getopts nclr:v:f:1spha: FLAG; do
+while getopts nclr:v:f:1spha:I FLAG; do
   case $FLAG in
     n)
       # Allow null database plugin ...
@@ -71,6 +71,9 @@ while getopts nclr:v:f:1spha: FLAG; do
       ;;
     a)
       export _adminPassword=${OPTARG}
+      ;;
+    I)
+      export IGNORE_ERRORS=1
       ;;
     h)
       usage

--- a/docker/backup.usage
+++ b/docker/backup.usage
@@ -46,6 +46,11 @@ function usage () {
        This can be used with the '-f' option, see below, to prune specific backups or sets of backups.
        Use caution when using the '-f' option.
 
+    -I ignore errors
+       This flag can be used with the Restore Options, when restoring a postgres database, to continue the 
+       database restoration process when errors are encountered.  By default the postgres restoration script 
+       stops on the first error.
+
   Verify Options:
   ================
     The verify process performs the following basic operations:


### PR DESCRIPTION
- resolves #56
- Adds the `-I` option as discussed to control the value of `ON_ERROR_STOP` in the postgres onRestoreDatabase implementation.
- An `ignoreErrors` function was added to allow other implementations and scripts to test for the "ignore errors" option.