### PR TITLE
OCP4_Fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ ADD https://github.com/$SOURCE_REPO/go-crond/releases/download/$GOCROND_VERSION/
 
 USER root
 
-RUN chmod ug+x /usr/bin/go-crond
+RUN chmod +x /usr/bin/go-crond
 # ========================================================================================================
 
 # ========================================================================================================

--- a/openshift/templates/backup/backup-build.json
+++ b/openshift/templates/backup/backup-build.json
@@ -43,7 +43,11 @@
         "strategy": {
           "type": "Docker",
           "dockerStrategy": {
-            "dockerfilePath": "${DOCKER_FILE_PATH}"
+            "from": {
+              "kind": "DockerImage",
+              "name": "${BASE_IMAGE_FOR_BUILD}"
+            },
+            "dockerfilePath": "Dockerfile"
           }
         },
         "output": {
@@ -97,6 +101,13 @@
       "description": "The tag given to the built image.",
       "required": true,
       "value": "latest"
+    },
+    {
+      "name": "BASE_IMAGE_FOR_BUILD",
+      "displayName": "FROM Image Tag",
+      "description": "Base image to build from.  Docker creds or Artificatory setup may be needed to alleviate docker rate-limiting",
+      "required": true,
+      "value": "docker.io/centos/postgresql-12-centos7:20200917-804ef01"
     }
   ]
 }


### PR DESCRIPTION
Update Backup-container for OCP4 

1. Fix bug with group permissions to go-crond
2. Added From builder image to resolve issues with docker rate limiting.