### PR TITLE
Fix url encoding issue causing webhook message delivery to fail

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,6 @@ WORKDIR /
 # Load the backup scripts into the container (must be executable).
 COPY backup.* /
 
-COPY webhook-template.json /
-
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
 #  - Adds some additional logging enhancements on top of the upstream project; 

--- a/docker/Dockerfile_MSSQL
+++ b/docker/Dockerfile_MSSQL
@@ -9,8 +9,6 @@ WORKDIR /
 # Load the backup scripts into the container (must be executable).
 COPY backup.* /
 
-COPY webhook-template.json /
-
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
 #  - Adds some additional logging enhancements on top of the upstream project; 

--- a/docker/Dockerfile_MariaDB
+++ b/docker/Dockerfile_MariaDB
@@ -9,8 +9,6 @@ WORKDIR /
 # Load the backup scripts into the container (must be executable).
 COPY backup.* /
 
-COPY webhook-template.json /
-
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
 #  - Adds some additional logging enhancements on top of the upstream project; 

--- a/docker/Dockerfile_Mongo
+++ b/docker/Dockerfile_Mongo
@@ -10,8 +10,6 @@ WORKDIR /
 # Load the backup scripts into the container (must be executable).
 COPY backup.* /
 
-COPY webhook-template.json /
-
 # ========================================================================================================
 # Install go-crond (from https://github.com/BCDevOps/go-crond)
 #  - Adds some additional logging enhancements on top of the upstream project; 

--- a/docker/backup.logging
+++ b/docker/backup.logging
@@ -77,35 +77,25 @@ function logError(){
   )
 }
 
-function getWebhookPayload(){
-  _payload=$(eval "cat <<-EOF
-$(<${WEBHOOK_TEMPLATE})
-EOF
-")
-  echo "${_payload}"
-}
-
-function formatWebhookMsg(){
-  (
-    # Escape all double quotes
-    # Escape all newlines
-    filters='s~"~\\"~g;:a;N;$!ba;s~\n~\\n~g;'
-    _value=$(echo "${1}" | sed "${filters}")
-    echo "${_value}"
-  )
-}
-
 function postMsgToWebhook(){
   (
-    if [ -z "${WEBHOOK_URL}" ] && [ -f ${WEBHOOK_TEMPLATE} ]; then
+    if [ -z "${WEBHOOK_URL}" ]; then
       return 0
     fi
 
     projectFriendlyName=${1}
     projectName=${2}
     statusCode=${3}
-    message=$(formatWebhookMsg "${4}")
-    curl -s -X POST -H 'Content-Type: application/json' --data "$(getWebhookPayload)" "${WEBHOOK_URL}" > /dev/null
+    message=$(echo -e "${4}")
+
+    curl -s \
+      -X POST \
+      -H "Content-Type: application/x-www-form-urlencoded" \
+      --data-urlencode "projectFriendlyName=${projectFriendlyName}" \
+      --data-urlencode "projectName=${projectName}" \
+      --data-urlencode "statusCode=${statusCode}" \
+      --data-urlencode "message=${message}" \
+      "${WEBHOOK_URL}" > /dev/null
   )
 }
 # =================================================================================================================

--- a/docker/backup.settings
+++ b/docker/backup.settings
@@ -30,9 +30,6 @@ export DAILY_BACKUPS=${DAILY_BACKUPS:-6}
 export WEEKLY_BACKUPS=${WEEKLY_BACKUPS:-4}
 export MONTHLY_BACKUPS=${MONTHLY_BACKUPS:-1}
 
-# Webhook defaults
-WEBHOOK_TEMPLATE=${WEBHOOK_TEMPLATE:-webhook-template.json}
-
 # Modes:
 export ONCE="once"
 export SCHEDULED="scheduled"

--- a/docker/webhook-template.json
+++ b/docker/webhook-template.json
@@ -1,6 +1,0 @@
-{
-  "projectFriendlyName": "${projectFriendlyName}",
-  "projectName": "${projectName}",
-  "statusCode": "${statusCode}",
-  "message": "${message}"
-}


### PR DESCRIPTION
- Format messages before sending.
- Use curl's `--data-urlencode` flag to properly url encode message content.
- Remove the webhook template.
- Remove all manual message escaping.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>