### PR TITLE
Fix broken helm-charts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ helm repo add bcgov http://bcgov.github.io/helm-charts
 helm upgrade --install db-backup-storage bcgov/backup-storage
 ```
 
-For customizing the configuration, go to: https://github.com/bcgov/helm-charts/tree/master/backup-storage
+For customizing the configuration, go to: https://github.com/bcgov/helm-charts/tree/master/charts/backup-storage
 
 # Prebuilt Container Images
 


### PR DESCRIPTION
The directory in the helm-charts repo appears to have been moved from:

https://github.com/bcgov/helm-charts/tree/master/backup-storage

to: 

https://github.com/bcgov/helm-charts/tree/master/charts/backup-storage