### PR TITLE
Revert postgres plugin to use gzip and gunzip

### DIFF
--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -29,8 +29,8 @@ function onBackupDatabase(){
 
     export PGPASSWORD=${_password}
     pg_dump -Fp -h "${_hostname}" ${_portArg} -U "${_username}" "${_database}" > "${BACKUP_DIR}backup.sql"
-    pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}"  --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
-    tar -C ${BACKUP_DIR} -cvzf ${_backupFile} backup.sql roles.sql
+    pg_dumpall -h "${_hostname}" ${_portArg} -U "${_username}" --roles-only --no-role-passwords > "${BACKUP_DIR}roles.sql"
+    cat "${BACKUP_DIR}roles.sql" "${BACKUP_DIR}backup.sql" | gzip > ${_backupFile}
     rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"
     return ${PIPESTATUS[0]}
   )
@@ -94,10 +94,7 @@ function onRestoreDatabase(){
 
     # Restore
     if (( ${_rtnCd} == 0 )); then
-      tar -xzvf "${_fileName}" -C ${BACKUP_DIR}
-      psql ${_stopOnErrors} -x -h "${_hostname}" ${_portArg} -d "${_database}" < "${BACKUP_DIR}roles.sql"
-      psql ${_stopOnErrors} -x -h "${_hostname}" ${_portArg} -d "${_database}" < "${BACKUP_DIR}backup.sql"
-      rm "${BACKUP_DIR}roles.sql" && rm "${BACKUP_DIR}backup.sql"
+      gunzip -c "${_fileName}" | psql ${_stopOnErrors} -x -h "${_hostname}" ${_portArg} -d "${_database}"
       # Get the status code from psql specifically.  ${?} would only provide the status of the last command, psql in this case.
       _rtnCd=${PIPESTATUS[1]}
     fi


### PR DESCRIPTION
While the change introduced in #115 achieves role backups, the switch from the gzip/gunzip tool to tar introduces file boundary artifacts in the backup stream, which psql is unable to handle. By rolling back to using gzip/gunzip in lieu of tar, we are able to concatenate and preserve equivalent behavior, but without the extraneous file boundary markers.

![Capture](https://github.com/BCDevOps/backup-container/assets/1546326/0e95bd7e-8185-416a-9b8b-aefb5942b54d)
