### PR TITLE
fix: allow backup verification and restore to work with patroni

### DIFF
--- a/docker/backup.postgres.plugin
+++ b/docker/backup.postgres.plugin
@@ -85,6 +85,17 @@ function onRestoreDatabase(){
       echo
     fi
 
+    # Drop Patroni-specific schemas
+    if (( ${_rtnCd} == 0 )); then
+      psql -h "${_hostname}" ${_portArg} -a -d ${_database} <<EOF
+DROP SCHEMA IF EXISTS metric_helpers CASCADE;
+DROP SCHEMA IF EXISTS user_management CASCADE;
+EOF
+
+      _rtnCd=${?}
+      echo
+    fi
+
     # Grant User Access
     if (( ${_rtnCd} == 0 )); then
       psql -h "${_hostname}" ${_portArg} -ac "GRANT ALL ON DATABASE \"${_database}\" TO \"${_username}\";"


### PR DESCRIPTION
This drops the metric helpers and user management schemas used by patroni, allowing the backup container to verify and restore patroni stateful sets (using postgres 13 server specifically).  
Note the -I flag is still needed for these to work:
`/backup.sh -I -r  <databaseSpec/>`

and 

`./backup.sh -I -v all`

To validate the db.